### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": "^7.0",
         "spatie/url-signer": "^1.0.1",
-        "illuminate/support": "~5.4.0|~5.5.x-dev",
-        "illuminate/http": "~5.4.0|~5.5.x-dev"
+        "illuminate/support": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/http": "~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.4|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.4|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -49,3 +49,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
+        "php": "^7.0",
         "spatie/url-signer": "^1.0.1",
-        "illuminate/support": "~5.4.0",
-        "illuminate/http": "~5.4.0"
+        "illuminate/support": "~5.4.0|~5.5.x-dev",
+        "illuminate/http": "~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.4",
-        "phpunit/phpunit" : "6.0"
+        "orchestra/testbench": "~3.4.4|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 284 ms, Memory: 10.00MB

OK (4 tests, 6 assertions)

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments